### PR TITLE
Clear browser cache every time GUI is started

### DIFF
--- a/jxbrowser/nbproject/project.xml
+++ b/jxbrowser/nbproject/project.xml
@@ -24,6 +24,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.openide.modules</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.48.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
+++ b/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
@@ -6,6 +6,8 @@
 package org.opensim.javabrowser;
 
 import com.teamdev.jxbrowser.chromium.Browser;
+import com.teamdev.jxbrowser.chromium.BrowserContext;
+import com.teamdev.jxbrowser.chromium.BrowserContextParams;
 import com.teamdev.jxbrowser.chromium.BrowserType;
 import com.teamdev.jxbrowser.chromium.events.LoadListener;
 import com.teamdev.jxbrowser.chromium.events.RenderEvent;
@@ -18,6 +20,7 @@ import javax.swing.SwingUtilities;
 import org.netbeans.api.settings.ConvertAsProperties;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
+import org.openide.modules.Places;
 import org.openide.windows.TopComponent;
 import org.openide.util.NbBundle.Messages;
 
@@ -51,8 +54,17 @@ public final class jxBrowserTopComponent extends TopComponent {
 
     public jxBrowserTopComponent() {
         initComponents();
-
-        browser = new Browser(BrowserType.HEAVYWEIGHT);
+        
+        BrowserContextParams bcp = new BrowserContextParams(
+            Places.getUserDirectory() + "/EmbeddedBrowserCache");
+        BrowserContext browserContext = new BrowserContext(bcp);
+        browser = new Browser(BrowserType.HEAVYWEIGHT, browserContext);
+        // This clears the cache in the <user-dir>/EmbeddedBrowserCache/Cache
+        // folder (asynchronously). Doing so is necessary to ensure that Models
+        // reliably show up in the visualizer. It's important to not delete
+        // the entire EmbeddedBrowserCache folder, so as to retain user
+        // settings for the floor, etc.
+        browser.getCacheStorage().clearCache();
         view = new BrowserView(browser);
         jPanel1.add(view);
         browser.loadURL("http://localhost:8002/threejs/editor/index.html");


### PR DESCRIPTION
Also, store the browser cache in the user dir.

This PR fixes the bug where one cannot see a model in the embedded visualizer after restarting the GUI, because one cannot refresh the webpage in the embedded visualizer.

Also, this PR stores the browser cache in the user dir (e.g., `~/Library/Application Support/OpenSim/<version>/EmbeddedBrowserCache`) so it can be easily deleted if necessary.

See the comments in the code for more information.

After this is merged, I can open a corresponding PR in the GUI to update the submodule.