### PR TITLE
force ignoring cache on reload

### DIFF
--- a/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
+++ b/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
@@ -141,7 +141,7 @@ public final class jxBrowserTopComponent extends TopComponent implements Observe
                 //OpenSimDB.getInstance().deleteObserver(this);
             }
             else if (arg instanceof ObjectSetCurrentEvent){
-                browser.reload();
+                browser.reloadIgnoringCache(true);
                 OpenSimDB.getInstance().deleteObserver(this);
             }
         }


### PR DESCRIPTION
Use reloadIgnoringCache to load the visualization into browser on entry.