### PR TITLE
Show loaded models in embedded browser on open.

### DIFF
--- a/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
+++ b/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
@@ -82,7 +82,10 @@ public final class jxBrowserTopComponent extends TopComponent implements Observe
         jPanel1.add(view);
         ViewDB.startVisualizationServer();
         OpenSimDB.getInstance().addObserver(this);
-        browser.loadHTML("<html><body></body></html>");
+        if (OpenSimDB.getInstance().hasModels())
+            browser.loadURL("http://localhost:8002/threejs/editor/index.html");
+        else
+            browser.loadHTML("<html><body></body></html>");
         jPanel1.validate();
          
         setName(Bundle.CTL_jxBrowserTopComponent());


### PR DESCRIPTION
If models were open in the application before opening embedded browser they didn't show up. This PR fixes such issue.