### PR TITLE
Disable drop into browser window.

### DIFF
--- a/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
+++ b/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
@@ -79,6 +79,7 @@ public final class jxBrowserTopComponent extends TopComponent implements Observe
         // settings for the floor, etc.
         browser.getCacheStorage().clearCache();
         view = new BrowserView(browser);
+        view.setDragAndDropEnabled(false); // Disable DnD altogther
         jPanel1.add(view);
         ViewDB.startVisualizationServer();
         OpenSimDB.getInstance().addObserver(this);


### PR DESCRIPTION
Disable any Drop (as in Drag-and-drop) in Browser window to avoid the xml display or unexpected message regarding .osim files disallowed.