### PR TITLE
Disable gpu blacklist

### DIFF
--- a/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
+++ b/jxbrowser/src/org/opensim/javabrowser/jxBrowserTopComponent.java
@@ -74,6 +74,7 @@ public final class jxBrowserTopComponent extends TopComponent implements Observe
         if (savedGPU.equalsIgnoreCase("off")){
             BrowserPreferences.setChromiumSwitches("--disable-gpu");
         }
+        BrowserPreferences.setChromiumSwitches("--ignore-gpu-blacklist");
         if (savedLightWeight.equalsIgnoreCase("on"))
             browser = new Browser(BrowserType.LIGHTWEIGHT, browserContext);
         else 


### PR DESCRIPTION
Attempt to run 4.0 visualization on older gfx card that is not WebGL approved.