### PR TITLE
Fix vertical spacing on welcome page

### DIFF
--- a/jxbrowser/src/org/opensim/javabrowser/welcome.html
+++ b/jxbrowser/src/org/opensim/javabrowser/welcome.html
@@ -79,7 +79,6 @@
                               <li><a target="_blank" href="http://simtk-confluence.stanford.edu/display/OpenSim40/Courses" style="color:#326ca6">Courses</a></li>
                               <li><a target="_blank" href="http://simtk-confluence.stanford.edu/display/OpenSim40/Teaching+Materials" style="color:#326ca6">Teaching Materials</a></li>
                           </ul>
-                          <br />
                       </td></tr>
                   </table>
               </td>


### PR DESCRIPTION
Cloned and checked it this time :smile:

**Before**
![](https://user-images.githubusercontent.com/4203505/40219636-16f6a506-5a2b-11e8-943f-ae16d9822af5.png)

**After**
![](https://user-images.githubusercontent.com/4203505/40219638-19bc4f70-5a2b-11e8-8c6d-2ec085e007e7.png)